### PR TITLE
chore: update to .NET 8 LTS

### DIFF
--- a/Feedster.DAL/Feedster.DAL.csproj
+++ b/Feedster.DAL/Feedster.DAL.csproj
@@ -7,19 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.0.0" />
-      <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-      <PackageReference Include="System.ServiceModel.Syndication" Version="8.0.0" />
+        <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.7.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.19" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.19" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.19" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+        <PackageReference Include="System.ServiceModel.Syndication" Version="8.0.0" />
     </ItemGroup>
-
-
-	<!-->ItemGroup>
-      <Reference Include="Microsoft.Extensions.Hosting.Abstractions">
-        <HintPath>..\..\..\..\..\..\Program Files\dotnet\shared\Microsoft.AspNetCore.App\6.0.8\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
-      </Reference>
-    </ItemGroup-->
-
 </Project>

--- a/Feedster.DAL/Migrations/20220927122832_Initial.Designer.cs
+++ b/Feedster.DAL/Migrations/20220927122832_Initial.Designer.cs
@@ -17,7 +17,7 @@ namespace Feedster.DAL.Migrations
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "6.0.8");
+            modelBuilder.HasAnnotation("ProductVersion", "8.0.19");
 
             modelBuilder.Entity("FeedFolder", b =>
                 {

--- a/Feedster.DAL/Migrations/20220929083048_Add darkmode.Designer.cs
+++ b/Feedster.DAL/Migrations/20220929083048_Add darkmode.Designer.cs
@@ -17,7 +17,7 @@ namespace Feedster.DAL.Migrations
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "6.0.8");
+            modelBuilder.HasAnnotation("ProductVersion", "8.0.19");
 
             modelBuilder.Entity("FeedFolder", b =>
                 {

--- a/Feedster.DAL/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Feedster.DAL/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -15,7 +15,7 @@ namespace Feedster.DAL.Migrations
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "6.0.8");
+            modelBuilder.HasAnnotation("ProductVersion", "8.0.19");
 
             modelBuilder.Entity("FeedFolder", b =>
                 {

--- a/Feedster.Web/Feedster.Web.csproj
+++ b/Feedster.Web/Feedster.Web.csproj
@@ -9,18 +9,18 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.8" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8">
+                <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.19" />
+                <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.19" />
+                <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.19" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.19" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.19" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.19">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-	</ItemGroup>
+                <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+                <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
+        </ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Feedster.DAL\Feedster.DAL.csproj" />


### PR DESCRIPTION
## Summary
- update dependencies to latest .NET 8 LTS patch releases
- align EF Core migration metadata with .NET 8

## Testing
- `dotnet build -p:RestoreExecuting=true`
- `dotnet test -p:RestoreExecuting=true`


------
https://chatgpt.com/codex/tasks/task_e_6899e179e5c083218fdb29086c2ce794