### PR TITLE
Remove BOM from package.json to fix PostCSS during Docker build

### DIFF
--- a/Feedster.Web/package.json
+++ b/Feedster.Web/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "scripts": {
     "buildcss:dev": "cross-env TAILWIND_MODE=build postcss ./Styles/app.css -o ./wwwroot/css/app.css",
     "buildcss:release": "cross-env NODE_ENV=production postcss ./Styles/app.css -o ./wwwroot/css/app.css"


### PR DESCRIPTION
## Summary
- remove stray Byte Order Mark from `Feedster.Web/package.json` so `npm run buildcss:release` succeeds

## Testing
- `npm run buildcss:release`
- `dotnet build Feedster.Web.csproj -c Release -o /tmp/build`


------
https://chatgpt.com/codex/tasks/task_e_6899ea0c2bb483219ece365e0f0b35f6