### PR TITLE
chore: streamline Dockerfile and reduce layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,15 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 WORKDIR /src
 
-# Install Node.js, NPM, and build tools
-# Use non-interactive apt-get to avoid prompts during image build
-RUN apt-get update && apt-get install -y --no-install-recommends curl gnupg build-essential
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
-RUN apt-get install -y nodejs
+# Install Node.js, NPM and build tools in a single layer then cleanup
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl gnupg build-essential \
+    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
 
 # Verify Node.js and NPM installation
-RUN node -v
-RUN npm -v
+RUN node -v && npm -v
 
 # Copy package files and install dependencies
 COPY Feedster.Web/package*.json ./Feedster.Web/
@@ -20,7 +20,7 @@ WORKDIR /src/Feedster.Web
 ENV NODE_ENV=development
 
 # Install NPM dependencies including devDependencies
-RUN npm install
+RUN npm ci
 
 # Reset NODE_ENV to production for the build
 ENV NODE_ENV=production
@@ -31,11 +31,8 @@ COPY . /src
 # Restore .NET dependencies
 RUN dotnet restore "Feedster.Web.csproj"
 
-# Build the project
-RUN dotnet build "Feedster.Web.csproj" -c Release -o /app/build
-
-# Publish the project
-RUN dotnet publish "Feedster.Web.csproj" -c Release -o /app/publish /p:UseAppHost=false
+# Publish the project (build + publish) without restoring again
+RUN dotnet publish "Feedster.Web.csproj" -c Release -o /app/publish /p:UseAppHost=false --no-restore
 
 # Stage 2: Build the runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base


### PR DESCRIPTION
## Summary
- streamline Node.js setup into single layer and clean apt cache
- use npm ci for reproducible installs and drop redundant build step

## Testing
- `npm ci`

------
https://chatgpt.com/codex/tasks/task_e_6899ef76faa48321aee0d3b763ba29c1