### PR TITLE
fix: upgrade Node.js to v20 to resolve npm engine mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /src
 # Install Node.js, NPM and build tools in a single layer then cleanup
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl gnupg build-essential \
-    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
     && npm install -g npm@11.5.2 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- use NodeSource 20.x setup so Node.js v20 is installed in the build stage
- keep npm 11.5.2 installation, avoiding EBADENGINE errors during Docker builds

## Testing
- `docker build --target build-env -t feedster-build-env .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- Attempted to start `dockerd`, but it exited due to missing permissions for iptables (bridge driver)


------
https://chatgpt.com/codex/tasks/task_e_6899fa8b0b1c8321b7cc3464b4bbdf20