### PR TITLE
Default to port 8080 and update Docker tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,8 @@ RUN dotnet publish "Feedster.Web.csproj" -c Release -o /app/publish /p:UseAppHos
 # Stage 2: Build the runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
-EXPOSE 80
-EXPOSE 443
+EXPOSE 8080
+EXPOSE 8443
 
 FROM base AS final
 WORKDIR /app

--- a/Feedster.Web/Program.cs
+++ b/Feedster.Web/Program.cs
@@ -14,6 +14,9 @@ using Microsoft.Extensions.FileProviders;
 
 var builder = WebApplication.CreateBuilder(args);
 
+var port = Environment.GetEnvironmentVariable("PORT") ?? "8080";
+builder.WebHost.UseUrls($"http://0.0.0.0:{port}");
+
 // Add services to the container.
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
 builder.Services.AddDbContext<ApplicationDbContext>(options =>

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ In the below command, the application will be accessible at http://localhost:300
 ```
 docker run -d \
     --restart unless-stopped \
-    -p 30080:80 \
+    -p 30080:8080 \
     -v  /your/path:/app/data \
     -v  /your/path:/app/images \
     index.docker.io/nl2109/feedster:latest
@@ -94,7 +94,7 @@ docker run -d \
 ### Docker Compose Example
 In the below docker-compose.yml example, the application will be accessible at http://localhost:30080 on the host and the files including the database for all the articles would be stored in /your/path/data/ folder.
 ```
-version: '3.4'
+version: '3.9'
 services:
     feedster:
         image: index.docker.io/nl2109/feedster:latest
@@ -104,5 +104,5 @@ services:
           - /your/path:/app/data
 	  - /your/path:/app/images
         ports:
-          - '30080:80'
+          - '30080:8080'
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+services:
+  feedster:
+    build: .
+    container_name: feedster
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./data:/app/data
+      - ./images:/app/images


### PR DESCRIPTION
## Summary
- Default application host to listen on port 8080
- Adjust Dockerfile and add docker-compose.yml with Compose v3.9
- Document new port and Compose version in README

## Testing
- `dotnet test`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a0076e8908321b552f3ae51b2d03b