### PR TITLE
Add OPML import and export for feeds

### DIFF
--- a/Feedster.DAL/Services/OpmlService.cs
+++ b/Feedster.DAL/Services/OpmlService.cs
@@ -1,0 +1,121 @@
+using System.Xml.Linq;
+using Feedster.DAL.Models;
+using Feedster.DAL.Repositories;
+
+namespace Feedster.DAL.Services;
+
+public class OpmlService
+{
+    private readonly FeedRepository _feedRepo;
+    private readonly FolderRepository _folderRepo;
+
+    public OpmlService(FeedRepository feedRepo, FolderRepository folderRepo)
+    {
+        _feedRepo = feedRepo;
+        _folderRepo = folderRepo;
+    }
+
+    public async Task<string> ExportAsync()
+    {
+        var folders = await _folderRepo.GetAll();
+        var feeds = await _feedRepo.GetAll();
+
+        var body = new XElement("body");
+
+        foreach (var folder in folders)
+        {
+            var folderElement = new XElement("outline",
+                new XAttribute("text", folder.Name),
+                new XAttribute("title", folder.Name));
+
+            foreach (var feed in folder.Feeds)
+            {
+                folderElement.Add(FeedToOutline(feed));
+            }
+
+            body.Add(folderElement);
+        }
+
+        foreach (var feed in feeds.Where(f => f.Folders.Count == 0))
+        {
+            body.Add(FeedToOutline(feed));
+        }
+
+        var doc = new XDocument(
+            new XDeclaration("1.0", "UTF-8", "yes"),
+            new XElement("opml", new XAttribute("version", "2.0"),
+                new XElement("head", new XElement("title", "Feedster Export")),
+                body));
+
+        return doc.ToString();
+    }
+
+    public async Task ImportAsync(Stream stream)
+    {
+        var doc = XDocument.Load(stream);
+        var body = doc.Root?.Element("body");
+        if (body == null) return;
+
+        var existingFolders = await _folderRepo.GetAll();
+        var existingFeeds = await _feedRepo.GetAll();
+
+        foreach (var outline in body.Elements("outline"))
+        {
+            var xmlUrl = outline.Attribute("xmlUrl")?.Value;
+            if (!string.IsNullOrEmpty(xmlUrl))
+            {
+                await CreateFeed(outline, null, existingFeeds);
+                continue;
+            }
+
+            var folderName = outline.Attribute("title")?.Value ?? outline.Attribute("text")?.Value;
+            if (string.IsNullOrWhiteSpace(folderName)) continue;
+
+            var folder = existingFolders.FirstOrDefault(f => f.Name == folderName);
+            if (folder == null)
+            {
+                folder = new Folder { Name = folderName };
+                await _folderRepo.Create(folder);
+                existingFolders.Add(folder);
+            }
+
+            foreach (var feedOutline in outline.Elements("outline"))
+            {
+                await CreateFeed(feedOutline, folder, existingFeeds);
+            }
+        }
+    }
+
+    private static XElement FeedToOutline(Feed feed)
+    {
+        return new XElement("outline",
+            new XAttribute("type", "rss"),
+            new XAttribute("text", feed.Name),
+            new XAttribute("title", feed.Name),
+            new XAttribute("xmlUrl", feed.RssUrl));
+    }
+
+    private async Task CreateFeed(XElement outline, Folder? folder, List<Feed> existingFeeds)
+    {
+        var url = outline.Attribute("xmlUrl")?.Value;
+        if (string.IsNullOrEmpty(url)) return;
+
+        if (existingFeeds.Any(f => f.RssUrl == url)) return;
+
+        var name = outline.Attribute("title")?.Value ?? outline.Attribute("text")?.Value ?? url;
+
+        var feed = new Feed
+        {
+            Name = name,
+            RssUrl = url
+        };
+
+        if (folder != null)
+        {
+            feed.Folders.Add(folder);
+        }
+
+        await _feedRepo.Create(feed);
+        existingFeeds.Add(feed);
+    }
+}

--- a/Feedster.Web/Controllers/OpmlController.cs
+++ b/Feedster.Web/Controllers/OpmlController.cs
@@ -1,0 +1,39 @@
+using System.Text;
+using Feedster.DAL.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Feedster.Web.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class OpmlController : ControllerBase
+{
+    private readonly OpmlService _opmlService;
+
+    public OpmlController(OpmlService opmlService)
+    {
+        _opmlService = opmlService;
+    }
+
+    [HttpGet("export")]
+    public async Task<IActionResult> Export()
+    {
+        var content = await _opmlService.ExportAsync();
+        var bytes = Encoding.UTF8.GetBytes(content);
+        return File(bytes, "text/xml", "feeds.opml");
+    }
+
+    [HttpPost("import")]
+    public async Task<IActionResult> Import(IFormFile file)
+    {
+        if (file == null || file.Length == 0)
+        {
+            return BadRequest("File is empty");
+        }
+
+        using var stream = file.OpenReadStream();
+        await _opmlService.ImportAsync(stream);
+
+        return Ok();
+    }
+}

--- a/Feedster.Web/Pages/Settings/Settings.razor
+++ b/Feedster.Web/Pages/Settings/Settings.razor
@@ -3,6 +3,7 @@
 @inject ImageService _ImageService
 @inject ArticleRepository _articleRepo
 @inject NavigationManager _navManager
+@inject HttpClient _httpClient
 
 <PageTitle>Feedster - Settings</PageTitle>
 
@@ -109,6 +110,15 @@
                 <a class="align-middle" style="display:inline-block">Clear</a>
             </button>
         </div>
+
+        <h5 class="mb-2 font-bold tracking-tight dark:text-white space-mono dark:brightness-[0.85]" style="font-size: 1.5em">Import / Export</h5>
+
+        <div class="max-w-sm grid grid-cols-2 gap-4 mb-5">
+            <button @onclick="ExportOpml" class="dark:border-gray-600 dark:hover:text-white dark:hover:bg-indigo-700 dark:focus:ring-gray-800 dark:bg-indigo-600 dark:text-white col shadow-md max-w-full h-[3.75rem] text-gray-900 hover:text-white border border-gray-800 hover:bg-gray-900 focus:ring-4 focus:outline-none focus:ring-gray-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center">Export</button>
+            <div class="col shadow-md max-w-full h-[3.75rem]">
+                <InputFile OnChange="ImportOpml" accept=".opml" class="w-full h-full text-gray-900 border border-gray-800 dark:bg-indigo-600 dark:text-white dark:border-gray-600 rounded-lg p-2.5" />
+            </div>
+        </div>
         
     <button type="submit" class="dark:border-gray-600 dark:hover:text-white dark:hover:bg-indigo-700 dark:focus:ring-gray-800 dark:bg-indigo-600 dark:text-white w-1/2 shadow-md mb-4 text-green-600 hover:text-white border border-green-600 hover:bg-green-600 focus:ring-4 focus:outline-none focus:ring-gray-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center mr-2 mb-2">
         <svg style="display:inline-block" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
@@ -168,7 +178,30 @@
         LoadCacheSizes();
         ShowNotification("Images cleared!", "All images have been successfully cleared.");
     }
-    
+
+    private void ExportOpml()
+    {
+        _navManager.NavigateTo("api/Opml/export", forceLoad: true);
+    }
+
+    private async Task ImportOpml(InputFileChangeEventArgs e)
+    {
+        var file = e.File;
+        using var content = new MultipartFormDataContent();
+        using var stream = file.OpenReadStream(10 * 1024 * 1024);
+        content.Add(new StreamContent(stream), "file", file.Name);
+
+        var response = await _httpClient.PostAsync("api/Opml/import", content);
+        if (response.IsSuccessStatusCode)
+        {
+            ShowNotification("Import completed!", "Feeds imported successfully.");
+        }
+        else
+        {
+            ShowNotification("Import failed!", "Failed to import feeds.");
+        }
+    }
+
     private async Task ClearArticles()
     {
         await _articleRepo.ClearAllArticles();

--- a/Feedster.Web/Program.cs
+++ b/Feedster.Web/Program.cs
@@ -34,10 +34,12 @@ builder.Services.AddTransient<ArticleRepository>();
 builder.Services.AddTransient<UserRepository>();
 builder.Services.AddTransient<RssFetchService>();
 builder.Services.AddTransient<ImageService>();
+builder.Services.AddTransient<OpmlService>();
 builder.Services.AddHostedService<FeedUpdateDequeueService>();
 builder.Services.AddHostedService<ExpiredArticlesPurgeService>();
 builder.Services.AddHostedService<FeedUpdateSchedulerService>();
 builder.Services.AddSingleton<BackgroundJobs>();
+builder.Services.AddHttpClient();
 
 // ensure that paths exists and create if not
 Directory.CreateDirectory("./images");


### PR DESCRIPTION
## Summary
- add `OpmlService` to convert feeds and folders to and from OPML
- expose `/api/Opml/export` and `/api/Opml/import` endpoints
- add import/export controls on settings page

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689a032ffe548321a97cf6f815e3bf11