### PR TITLE
Refactor HTTP usage and resource management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,5 +47,9 @@ WORKDIR /app
 # Copy the published app from the build stage
 COPY --from=build-env /app/publish .
 
+# Create and use a non-root user
+RUN useradd -m appuser && chown -R appuser /app
+USER appuser
+
 # Set the entry point for the container
 ENTRYPOINT ["dotnet", "Feedster.Web.dll"]

--- a/Feedster.DAL.Tests/Feedster.DAL.Tests.csproj
+++ b/Feedster.DAL.Tests/Feedster.DAL.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Feedster.DAL\Feedster.DAL.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Feedster.DAL.Tests/GlobalUsings.cs
+++ b/Feedster.DAL.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Feedster.DAL.Tests/ImageServiceTests.cs
+++ b/Feedster.DAL.Tests/ImageServiceTests.cs
@@ -1,0 +1,45 @@
+using Feedster.DAL.Models;
+using Feedster.DAL.Services;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+public class ImageServiceTests
+{
+    [Fact]
+    public void ClearArticleImages_HandlesNullAndEmptyPaths()
+    {
+        Directory.CreateDirectory("images");
+        var existing = Path.Combine("images", "keep.jpg");
+        File.WriteAllText(existing, "data");
+        var articles = new List<Article>
+        {
+            new Article { ImagePath = null },
+            new Article { ImagePath = string.Empty }
+        };
+        var service = new ImageService();
+
+        service.ClearArticleImages(articles);
+
+        Assert.True(File.Exists(existing));
+
+        File.Delete(existing);
+        Directory.Delete("images", true);
+    }
+
+    [Fact]
+    public void ClearArticleImages_RemovesExistingFile()
+    {
+        Directory.CreateDirectory("images");
+        var path = Path.Combine("images", "to-delete.jpg");
+        File.WriteAllText(path, "data");
+        var articles = new List<Article> { new Article { ImagePath = "to-delete.jpg" } };
+        var service = new ImageService();
+
+        service.ClearArticleImages(articles);
+
+        Assert.False(File.Exists(path));
+
+        Directory.Delete("images", true);
+    }
+}

--- a/Feedster.DAL/BackgroundServices/ExpiredArticlesPurgeService.cs
+++ b/Feedster.DAL/BackgroundServices/ExpiredArticlesPurgeService.cs
@@ -52,9 +52,6 @@ public class ExpiredArticlesPurgeService : BackgroundService
                 // run once every 24 hours
                 _logger.LogInformation("Purge completed. Waiting 24 Hours until next purge");
 
-                scope.Dispose();
-                _userRepository.Dispose();
-
                 await Task.Delay(24 * 60 * 60 * 1000, stoppingToken);
             }
         }

--- a/Feedster.DAL/BackgroundServices/ExpiredArticlesPurgeService.cs
+++ b/Feedster.DAL/BackgroundServices/ExpiredArticlesPurgeService.cs
@@ -3,56 +3,52 @@ using Feedster.DAL.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using TimeProvider = System.TimeProvider;
 
 namespace Feedster.DAL.BackgroundServices;
 
 /// <summary>
 /// This service automatically purges articles and images of said articles after specific user defined setting
 /// </summary>
-public class ExpiredArticlesPurgeService : BackgroundService
+public class ExpiredArticlesPurgeService(
+    IServiceScopeFactory scopeFactory,
+    ILogger<ExpiredArticlesPurgeService> logger,
+    TimeProvider timeProvider) : BackgroundService
 {
-    private ArticleRepository? _articleRepo;
-    private UserRepository? _userRepository;
-    private readonly IServiceScopeFactory _scopeFactory;
-    private readonly ILogger<ExpiredArticlesPurgeService> _logger;
-
-    public ExpiredArticlesPurgeService(IServiceScopeFactory scopeFactory, ILogger<ExpiredArticlesPurgeService> logger)
-    {
-        _scopeFactory = scopeFactory;
-        _logger = logger;
-    }
+    private readonly IServiceScopeFactory _scopeFactory = scopeFactory;
+    private readonly ILogger<ExpiredArticlesPurgeService> _logger = logger;
+    private readonly TimeProvider _timeProvider = timeProvider;
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         _logger.LogInformation("Started ExpiredArticlesPurgeService. Waiting 10 minutes until first purge");
 
         // wait 10 minutes before starting service to let the updater update first
-        await Task.Delay(10 * 60 * 1000, stoppingToken);
+        await Task.Delay(TimeSpan.FromMinutes(10), stoppingToken);
 
         _logger.LogInformation("Starting first purge");
 
         while (!stoppingToken.IsCancellationRequested)
         {
-            using IServiceScope scope = _scopeFactory.CreateScope();
-            _articleRepo = scope.ServiceProvider.GetRequiredService<ArticleRepository>();
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var articleRepo = scope.ServiceProvider.GetRequiredService<ArticleRepository>();
+            var userRepository = scope.ServiceProvider.GetRequiredService<UserRepository>();
+            UserSettings userSettings = await userRepository.Get();
 
-            // Load user settings
-            _userRepository = scope.ServiceProvider.GetRequiredService<UserRepository>();
-            UserSettings _userSettings = await _userRepository.Get();
-
-            if (_userSettings.ArticleExpirationAfterDays == 0)
+            if (userSettings.ArticleExpirationAfterDays == 0)
             {
                 // auto purge turned off; recheck in 15 minutes
-                await Task.Delay(15 * 60 * 1000, stoppingToken);
+                await Task.Delay(TimeSpan.FromMinutes(15), stoppingToken);
             }
             else
             {
-                await _articleRepo.ClearArticlesOlderThan(DateTime.Now.AddDays(-_userSettings.ArticleExpirationAfterDays));
+                await articleRepo.ClearArticlesOlderThan(
+                    _timeProvider.GetLocalNow().DateTime.AddDays(-userSettings.ArticleExpirationAfterDays));
 
                 // run once every 24 hours
                 _logger.LogInformation("Purge completed. Waiting 24 Hours until next purge");
 
-                await Task.Delay(24 * 60 * 60 * 1000, stoppingToken);
+                await Task.Delay(TimeSpan.FromHours(24), stoppingToken);
             }
         }
     }

--- a/Feedster.DAL/BackgroundServices/FeedUpdateDequeueService.cs
+++ b/Feedster.DAL/BackgroundServices/FeedUpdateDequeueService.cs
@@ -39,7 +39,6 @@ public class FeedUpdateDequeueService : BackgroundService
             }
             await Task.Delay(1000, stoppingToken);
         }
-        scope.Dispose();
         _logger.LogInformation("Stopped FeedUpdateDequeueService");
     }
 }

--- a/Feedster.DAL/BackgroundServices/FeedUpdateDequeueService.cs
+++ b/Feedster.DAL/BackgroundServices/FeedUpdateDequeueService.cs
@@ -10,35 +10,31 @@ namespace Feedster.DAL.BackgroundServices;
 /// <summary>
 /// This service automatically runs every second and tries to dequeue tasks (fetching feeds) from the BackgroundJobs List
 /// </summary>
-public class FeedUpdateDequeueService : BackgroundService
+public class FeedUpdateDequeueService(
+    IServiceScopeFactory scopeFactory,
+    ILogger<FeedUpdateDequeueService> logger) : BackgroundService
 {
-    private  RssFetchService? _rssFetchService;
-    private  BackgroundJobs? _backgroundJobs;
-    private readonly IServiceScopeFactory _scopeFactory;
-    private readonly ILogger<FeedUpdateDequeueService> _logger;
-
-    public FeedUpdateDequeueService(IServiceScopeFactory scopeFactory, ILogger<FeedUpdateDequeueService> logger)
-    {
-        _scopeFactory = scopeFactory;
-        _logger = logger;
-    }
+    private readonly IServiceScopeFactory _scopeFactory = scopeFactory;
+    private readonly ILogger<FeedUpdateDequeueService> _logger = logger;
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         _logger.LogInformation("Started FeedUpdateDequeueService");
-        
-        using IServiceScope scope = _scopeFactory.CreateScope();
-        _backgroundJobs = scope.ServiceProvider.GetRequiredService<BackgroundJobs>();   
-        _rssFetchService = scope.ServiceProvider.GetRequiredService<RssFetchService>();   
-        
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var backgroundJobs = scope.ServiceProvider.GetRequiredService<BackgroundJobs>();
+        var rssFetchService = scope.ServiceProvider.GetRequiredService<RssFetchService>();
+
         while (!stoppingToken.IsCancellationRequested)
         {
-            if(_backgroundJobs.BackgroundTasks.TryDequeue(out var feeds))
+            if (backgroundJobs.BackgroundTasks.TryDequeue(out var feeds))
             {
-                await _rssFetchService.RefreshFeeds(feeds); 
+                await rssFetchService.RefreshFeeds(feeds);
             }
-            await Task.Delay(1000, stoppingToken);
+
+            await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
         }
+
         _logger.LogInformation("Stopped FeedUpdateDequeueService");
     }
 }

--- a/Feedster.DAL/BackgroundServices/FeedUpdateSchedulerService.cs
+++ b/Feedster.DAL/BackgroundServices/FeedUpdateSchedulerService.cs
@@ -52,7 +52,6 @@ public class FeedUpdateSchedulerService : BackgroundService
                 await Task.Delay(userSettings.ArticleRefreshAfterMinutes * 60 * 1000, stoppingToken);
             }
         }
-        scope.Dispose();
         _logger.LogInformation("Stopped FeedUpdateSchedulerService");
     }
 }

--- a/Feedster.DAL/BackgroundServices/FeedUpdateSchedulerService.cs
+++ b/Feedster.DAL/BackgroundServices/FeedUpdateSchedulerService.cs
@@ -10,48 +10,40 @@ namespace Feedster.DAL.BackgroundServices;
 /// <summary>
 /// This service automatically updates all feeds in the DB on a user defined interval
 /// </summary>
-public class FeedUpdateSchedulerService : BackgroundService
+public class FeedUpdateSchedulerService(
+    IServiceScopeFactory scopeFactory,
+    ILogger<FeedUpdateSchedulerService> logger) : BackgroundService
 {
-    private  BackgroundJobs? _backgroundJobs;
-    private  UserRepository? _userRepository;
-    private  FeedRepository? _feedRepository;
-    private readonly IServiceScopeFactory _scopeFactory;
-    private readonly ILogger<FeedUpdateSchedulerService> _logger;
-
-    public FeedUpdateSchedulerService(IServiceScopeFactory scopeFactory, ILogger<FeedUpdateSchedulerService> logger)
-    {
-        _scopeFactory = scopeFactory;
-        _logger = logger;
-    }
+    private readonly IServiceScopeFactory _scopeFactory = scopeFactory;
+    private readonly ILogger<FeedUpdateSchedulerService> _logger = logger;
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         _logger.LogInformation("Started FeedUpdateSchedulerService");
-        
-        using IServiceScope scope = _scopeFactory.CreateScope();
-        _backgroundJobs = scope.ServiceProvider.GetRequiredService<BackgroundJobs>();   
-        
+
         while (!stoppingToken.IsCancellationRequested)
         {
-            _feedRepository = scope.ServiceProvider.GetRequiredService<FeedRepository>();   
-            
-            // load user settings
-            _userRepository = scope.ServiceProvider.GetRequiredService<UserRepository>();
-            UserSettings userSettings = await _userRepository.Get();
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var backgroundJobs = scope.ServiceProvider.GetRequiredService<BackgroundJobs>();
+            var feedRepository = scope.ServiceProvider.GetRequiredService<FeedRepository>();
+            var userRepository = scope.ServiceProvider.GetRequiredService<UserRepository>();
+
+            UserSettings userSettings = await userRepository.Get();
 
             if (userSettings.ArticleRefreshAfterMinutes == 0)
             {
                 // auto fetch turned off; recheck in 15 minutes
-                await Task.Delay(15 * 60 * 1000, stoppingToken);
+                await Task.Delay(TimeSpan.FromMinutes(15), stoppingToken);
             }
             else
             {
-                // Update all Feeds currently in DB
-                List<Feed> feeds = await _feedRepository.GetAll();
-                _backgroundJobs.BackgroundTasks.Enqueue(feeds);
-                await Task.Delay(userSettings.ArticleRefreshAfterMinutes * 60 * 1000, stoppingToken);
+                // Update all feeds currently in DB
+                List<Feed> feeds = await feedRepository.GetAll();
+                backgroundJobs.BackgroundTasks.Enqueue(feeds);
+                await Task.Delay(TimeSpan.FromMinutes(userSettings.ArticleRefreshAfterMinutes), stoppingToken);
             }
         }
+
         _logger.LogInformation("Stopped FeedUpdateSchedulerService");
     }
 }

--- a/Feedster.DAL/Feedster.DAL.csproj
+++ b/Feedster.DAL/Feedster.DAL.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.19" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.19" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.8" />
         <PackageReference Include="System.ServiceModel.Syndication" Version="8.0.0" />
     </ItemGroup>
 </Project>

--- a/Feedster.DAL/Models/Validation/CustomValidatorAttribute.cs
+++ b/Feedster.DAL/Models/Validation/CustomValidatorAttribute.cs
@@ -12,18 +12,19 @@ public class CustomValidationAttribute : ValidationAttribute
     {
         if (rssUrl is not null)
         {
-            string content = rssUrl!.ToString()!.ToLower();
+            string content = rssUrl.ToString()!.ToLower();
+            var httpClientFactory = (IHttpClientFactory?)validationContext.GetService(typeof(IHttpClientFactory));
 
-            if (TryParseFeed(content))
+            if (httpClientFactory != null && TryParseFeed(content, httpClientFactory))
             {
                 return null;
             }
         }
 
-        return new ValidationResult(ErrorMessage, new List<string> { validationContext!.MemberName! });
+        return new ValidationResult(ErrorMessage, new List<string> { validationContext.MemberName! });
     }
 
-    private bool TryParseFeed(string url)
+    private bool TryParseFeed(string url, IHttpClientFactory httpClientFactory)
     {
         try
         {
@@ -33,7 +34,7 @@ public class CustomValidationAttribute : ValidationAttribute
                 IgnoreWhitespace = true
             };
 
-            using HttpClient httpClient = new();
+            var httpClient = httpClientFactory.CreateClient();
             httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
             httpClient.DefaultRequestHeaders.Accept.ParseAdd("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
             using var stream = httpClient.GetStreamAsync(url).Result;

--- a/Feedster.DAL/Repositories/ArticleRepository.cs
+++ b/Feedster.DAL/Repositories/ArticleRepository.cs
@@ -1,4 +1,4 @@
-﻿using Feedster.DAL.Data;
+using Feedster.DAL.Data;
 using Feedster.DAL.Models;
 using Feedster.DAL.Services;
 using Microsoft.EntityFrameworkCore;
@@ -6,60 +6,56 @@ using System;
 
 namespace Feedster.DAL.Repositories;
 
-public class ArticleRepository : IDisposable
+public class ArticleRepository(ApplicationDbContext db, ImageService imageService) : IDisposable, IAsyncDisposable
 {
-    private readonly ApplicationDbContext _db;
-    private readonly ImageService _imageService;
-
-    public ArticleRepository(ApplicationDbContext db, ImageService imageService)
-    {
-        _db = db;
-        _imageService = imageService;
-    }
+    private bool _disposed;
 
     public async Task<List<Article>> GetAll()
     {
-        var list = await _db.Articles.Include(a => a.Feed).ToListAsync();
+        var list = await db.Articles.Include(a => a.Feed).ToListAsync();
         return list;
     }
 
     public async Task UpdateRange(List<Article> articles)
     {
-        _db.Articles.UpdateRange(articles);
-        await _db.SaveChangesAsync();
+        db.Articles.UpdateRange(articles);
+        await db.SaveChangesAsync();
     }
 
     public async Task<List<Article>> GetFromFolderId(int id)
     {
-        return (await _db.Folders.Include(f => f.Feeds).ThenInclude(f => f.Articles)
+        return (await db.Folders.Include(f => f.Feeds).ThenInclude(f => f.Articles)
             .FirstOrDefaultAsync(f => f.FolderId == id))?.Feeds.SelectMany(f => f.Articles!).ToList() ?? new();
     }
 
     public async Task ClearAllArticles()
     {
-        _db.Articles.RemoveRange(_db.Articles);
-        _imageService.ClearImageCache();
-        await _db.SaveChangesAsync();
+        db.Articles.RemoveRange(db.Articles);
+        imageService.ClearImageCache();
+        await db.SaveChangesAsync();
     }
 
     public async Task ClearArticlesOlderThan(DateTime dateTime)
     {
-        var articlesToDelete = await _db.Articles.Where(x => x.PublicationDate < dateTime).ToListAsync();
-        _db.Articles.RemoveRange(articlesToDelete);
-        await _db.SaveChangesAsync();
-        _imageService.ClearArticleImages(articlesToDelete);
+        var articlesToDelete = await db.Articles.Where(x => x.PublicationDate < dateTime).ToListAsync();
+        db.Articles.RemoveRange(articlesToDelete);
+        await db.SaveChangesAsync();
+        imageService.ClearArticleImages(articlesToDelete);
     }
-
-    private bool _disposed;
 
     public void Dispose()
     {
-        if (!_disposed)
-        {
-            _db.Dispose();
-            _disposed = true;
-        }
+        if (_disposed) return;
+        db.Dispose();
+        _disposed = true;
+        GC.SuppressFinalize(this);
+    }
 
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        await db.DisposeAsync();
+        _disposed = true;
         GC.SuppressFinalize(this);
     }
 }

--- a/Feedster.DAL/Repositories/ArticleRepository.cs
+++ b/Feedster.DAL/Repositories/ArticleRepository.cs
@@ -2,10 +2,11 @@
 using Feedster.DAL.Models;
 using Feedster.DAL.Services;
 using Microsoft.EntityFrameworkCore;
+using System;
 
 namespace Feedster.DAL.Repositories;
 
-public class ArticleRepository
+public class ArticleRepository : IDisposable
 {
     private readonly ApplicationDbContext _db;
     private readonly ImageService _imageService;
@@ -49,8 +50,16 @@ public class ArticleRepository
         _imageService.ClearArticleImages(articlesToDelete);
     }
 
-    internal void Dispose()
+    private bool _disposed;
+
+    public void Dispose()
     {
-        _db.Dispose();
+        if (!_disposed)
+        {
+            _db.Dispose();
+            _disposed = true;
+        }
+
+        GC.SuppressFinalize(this);
     }
 }

--- a/Feedster.DAL/Repositories/FeedRepository.cs
+++ b/Feedster.DAL/Repositories/FeedRepository.cs
@@ -2,10 +2,11 @@
 using Feedster.DAL.Models;
 using Feedster.DAL.Services;
 using Microsoft.EntityFrameworkCore;
+using System;
 
 namespace Feedster.DAL.Repositories;
 
-public class FeedRepository
+public class FeedRepository : IDisposable
 {
     private readonly ApplicationDbContext _db;
     private readonly RssFetchService _rssFetchService;
@@ -49,8 +50,16 @@ public class FeedRepository
         return await _rssFetchService.RefreshFeed(feed);
     }
 
-    internal void Dispose()
+    private bool _disposed;
+
+    public void Dispose()
     {
-        _db.Dispose();
+        if (!_disposed)
+        {
+            _db.Dispose();
+            _disposed = true;
+        }
+
+        GC.SuppressFinalize(this);
     }
 }

--- a/Feedster.DAL/Repositories/FeedRepository.cs
+++ b/Feedster.DAL/Repositories/FeedRepository.cs
@@ -1,4 +1,4 @@
-﻿using Feedster.DAL.Data;
+using Feedster.DAL.Data;
 using Feedster.DAL.Models;
 using Feedster.DAL.Services;
 using Microsoft.EntityFrameworkCore;
@@ -6,60 +6,56 @@ using System;
 
 namespace Feedster.DAL.Repositories;
 
-public class FeedRepository : IDisposable
+public class FeedRepository(ApplicationDbContext db, RssFetchService rssFetchService) : IDisposable, IAsyncDisposable
 {
-    private readonly ApplicationDbContext _db;
-    private readonly RssFetchService _rssFetchService;
-
-    public FeedRepository(ApplicationDbContext db, RssFetchService rssFetchService)
-    {
-        _db = db;
-        _rssFetchService = rssFetchService;
-    }
+    private bool _disposed;
 
     public async Task<List<Feed>> GetAll()
     {
-        return await _db.Feeds.Include(f => f.Articles).ToListAsync();
+        return await db.Feeds.Include(f => f.Articles).ToListAsync();
     }
 
     public async Task Create(Feed feed)
     {
-        await _db.Feeds.AddAsync(feed);
-        await _db.SaveChangesAsync();
+        await db.Feeds.AddAsync(feed);
+        await db.SaveChangesAsync();
     }
 
     public async Task Update(Feed feed)
     {
-        _db.Feeds.Update(feed);
-        await _db.SaveChangesAsync();
+        db.Feeds.Update(feed);
+        await db.SaveChangesAsync();
     }
 
     public async Task<Feed?> Get(int id)
     {
-        return await _db.Feeds.Include(f => f.Articles).FirstOrDefaultAsync(f => f.FeedId == id);
+        return await db.Feeds.Include(f => f.Articles).FirstOrDefaultAsync(f => f.FeedId == id);
     }
 
     public async Task Remove(Feed feed)
     {
-        _db.Feeds.Remove(feed);
-        await _db.SaveChangesAsync();
+        db.Feeds.Remove(feed);
+        await db.SaveChangesAsync();
     }
 
     public async Task<int?> FetchFeed(Feed feed)
     {
-        return await _rssFetchService.RefreshFeed(feed);
+        return await rssFetchService.RefreshFeed(feed);
     }
-
-    private bool _disposed;
 
     public void Dispose()
     {
-        if (!_disposed)
-        {
-            _db.Dispose();
-            _disposed = true;
-        }
+        if (_disposed) return;
+        db.Dispose();
+        _disposed = true;
+        GC.SuppressFinalize(this);
+    }
 
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        await db.DisposeAsync();
+        _disposed = true;
         GC.SuppressFinalize(this);
     }
 }

--- a/Feedster.DAL/Repositories/FolderRepository.cs
+++ b/Feedster.DAL/Repositories/FolderRepository.cs
@@ -1,10 +1,11 @@
 ﻿using Feedster.DAL.Data;
 using Feedster.DAL.Models;
 using Microsoft.EntityFrameworkCore;
+using System;
 
 namespace Feedster.DAL.Repositories;
 
-public class FolderRepository
+public class FolderRepository : IDisposable
 {
     private readonly ApplicationDbContext _db;
 
@@ -41,8 +42,16 @@ public class FolderRepository
         await _db.SaveChangesAsync();
     }
 
-    internal void Dispose()
+    private bool _disposed;
+
+    public void Dispose()
     {
-        _db.Dispose();
+        if (!_disposed)
+        {
+            _db.Dispose();
+            _disposed = true;
+        }
+
+        GC.SuppressFinalize(this);
     }
 }

--- a/Feedster.DAL/Repositories/FolderRepository.cs
+++ b/Feedster.DAL/Repositories/FolderRepository.cs
@@ -1,57 +1,55 @@
-﻿using Feedster.DAL.Data;
+using Feedster.DAL.Data;
 using Feedster.DAL.Models;
 using Microsoft.EntityFrameworkCore;
 using System;
 
 namespace Feedster.DAL.Repositories;
 
-public class FolderRepository : IDisposable
+public class FolderRepository(ApplicationDbContext db) : IDisposable, IAsyncDisposable
 {
-    private readonly ApplicationDbContext _db;
-
-    public FolderRepository(ApplicationDbContext db)
-    {
-        _db = db;
-    }
+    private bool _disposed;
 
     public async Task<List<Folder>> GetAll()
     {
-        return await _db.Folders.Include(g => g.Feeds).ToListAsync();
+        return await db.Folders.Include(g => g.Feeds).ToListAsync();
     }
 
     public async Task Create(Folder folder)
     {
-        await _db.Folders.AddAsync(folder);
-        await _db.SaveChangesAsync();
+        await db.Folders.AddAsync(folder);
+        await db.SaveChangesAsync();
     }
 
     public async Task<Folder?> Get(int id)
     {
-        return await _db.Folders.FirstOrDefaultAsync(f => f.FolderId == id);
+        return await db.Folders.FirstOrDefaultAsync(f => f.FolderId == id);
     }
 
     public async Task Update(Folder folder)
     {
-        _db.Folders.Update(folder);
-        await _db.SaveChangesAsync();
+        db.Folders.Update(folder);
+        await db.SaveChangesAsync();
     }
 
     public async Task Remove(Folder folder)
     {
-        _db.Folders.Remove(folder);
-        await _db.SaveChangesAsync();
+        db.Folders.Remove(folder);
+        await db.SaveChangesAsync();
     }
-
-    private bool _disposed;
 
     public void Dispose()
     {
-        if (!_disposed)
-        {
-            _db.Dispose();
-            _disposed = true;
-        }
+        if (_disposed) return;
+        db.Dispose();
+        _disposed = true;
+        GC.SuppressFinalize(this);
+    }
 
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        await db.DisposeAsync();
+        _disposed = true;
         GC.SuppressFinalize(this);
     }
 }

--- a/Feedster.DAL/Repositories/UserRepository.cs
+++ b/Feedster.DAL/Repositories/UserRepository.cs
@@ -1,10 +1,11 @@
 using Feedster.DAL.Data;
 using Feedster.DAL.Models;
 using Microsoft.EntityFrameworkCore;
+using System;
 
 namespace Feedster.DAL.Repositories;
 
-public class UserRepository
+public class UserRepository : IDisposable
 {
     private readonly ApplicationDbContext _db;
 
@@ -24,8 +25,16 @@ public class UserRepository
         await _db.SaveChangesAsync();
     }
 
-    internal void Dispose()
+    private bool _disposed;
+
+    public void Dispose()
     {
-        _db.Dispose();
+        if (!_disposed)
+        {
+            _db.Dispose();
+            _disposed = true;
+        }
+
+        GC.SuppressFinalize(this);
     }
 }

--- a/Feedster.DAL/Repositories/UserRepository.cs
+++ b/Feedster.DAL/Repositories/UserRepository.cs
@@ -5,36 +5,34 @@ using System;
 
 namespace Feedster.DAL.Repositories;
 
-public class UserRepository : IDisposable
+public class UserRepository(ApplicationDbContext db) : IDisposable, IAsyncDisposable
 {
-    private readonly ApplicationDbContext _db;
-
-    public UserRepository(ApplicationDbContext db)
-    {
-        _db = db;
-    }
+    private bool _disposed;
 
     public async Task<UserSettings> Get()
     {
-        return await _db.UserSettings.FirstAsync();
+        return await db.UserSettings.FirstAsync();
     }
 
-    public async Task Update(UserSettings _userSettings)
+    public async Task Update(UserSettings userSettings)
     {
-        _db.UserSettings.Update(_userSettings);
-        await _db.SaveChangesAsync();
+        db.UserSettings.Update(userSettings);
+        await db.SaveChangesAsync();
     }
-
-    private bool _disposed;
 
     public void Dispose()
     {
-        if (!_disposed)
-        {
-            _db.Dispose();
-            _disposed = true;
-        }
+        if (_disposed) return;
+        db.Dispose();
+        _disposed = true;
+        GC.SuppressFinalize(this);
+    }
 
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        await db.DisposeAsync();
+        _disposed = true;
         GC.SuppressFinalize(this);
     }
 }

--- a/Feedster.DAL/Services/ImageService.cs
+++ b/Feedster.DAL/Services/ImageService.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Text;
 using Feedster.DAL.Models;
 using ImageMagick;
@@ -28,9 +29,13 @@ public class ImageService
     {
         foreach (var article in articles)
         {
-            if (!String.IsNullOrEmpty("./images/" + article.ImagePath) && File.Exists("./images/" + article.ImagePath))
+            if (!string.IsNullOrEmpty(article.ImagePath))
             {
-                File.Delete("./images/" + article.ImagePath);
+                var path = Path.Combine("images", article.ImagePath);
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
             }
         }
     }

--- a/Feedster.Web/Areas/Identity/RevalidatingIdentityAuthenticationStateProvider.cs
+++ b/Feedster.Web/Areas/Identity/RevalidatingIdentityAuthenticationStateProvider.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Server;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using System.Security.Claims;
 
@@ -28,24 +29,10 @@ namespace Feedster.Web.Areas.Identity
         protected override async Task<bool> ValidateAuthenticationStateAsync(
             AuthenticationState authenticationState, CancellationToken cancellationToken)
         {
-            // Get the user manager from a new scope to ensure it fetches fresh data
-            var scope = _scopeFactory.CreateScope();
-            try
-            {
-                var userManager = scope.ServiceProvider.GetRequiredService<UserManager<TUser>>();
-                return await ValidateSecurityStampAsync(userManager, authenticationState.User);
-            }
-            finally
-            {
-                if (scope is IAsyncDisposable asyncDisposable)
-                {
-                    await asyncDisposable.DisposeAsync();
-                }
-                else
-                {
-                    scope.Dispose();
-                }
-            }
+            // Use an async scope to ensure fresh data without manual disposal
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<TUser>>();
+            return await ValidateSecurityStampAsync(userManager, authenticationState.User);
         }
 
         private async Task<bool> ValidateSecurityStampAsync(UserManager<TUser> userManager, ClaimsPrincipal principal)

--- a/Feedster.sln
+++ b/Feedster.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Feedster.Web", "Feedster.We
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Feedster.DAL", "Feedster.DAL\Feedster.DAL.csproj", "{B87CA8A3-BEC2-4134-8F0A-FE4F07576A95}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Feedster.DAL.Tests", "Feedster.DAL.Tests\Feedster.DAL.Tests.csproj", "{7464AF72-C89C-4DE0-86C3-E2173BC00C31}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{B87CA8A3-BEC2-4134-8F0A-FE4F07576A95}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B87CA8A3-BEC2-4134-8F0A-FE4F07576A95}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B87CA8A3-BEC2-4134-8F0A-FE4F07576A95}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7464AF72-C89C-4DE0-86C3-E2173BC00C31}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7464AF72-C89C-4DE0-86C3-E2173BC00C31}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7464AF72-C89C-4DE0-86C3-E2173BC00C31}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7464AF72-C89C-4DE0-86C3-E2173BC00C31}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- inject `IHttpClientFactory` and logging into RssFetchService, replace direct `HttpClient` and `Random` usage
- fix image deletion logic and add unit tests
- implement `IDisposable` in repositories, clean up background services, and run container as non-root

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689c80e1f0b48321bfe386cec9028efa